### PR TITLE
TCP stop selection

### DIFF
--- a/libraries/ModbusIP/ModbusIP.cpp
+++ b/libraries/ModbusIP/ModbusIP.cpp
@@ -75,7 +75,9 @@ void ModbusIP::task() {
                 client.write(sendbuffer, _len + 7);
             }
 
+#ifdef TCP_STOP
             client.stop();
+#endif
             free(_frame);
             _len = 0;
         }

--- a/libraries/ModbusIP/ModbusIP.h
+++ b/libraries/ModbusIP/ModbusIP.h
@@ -1,6 +1,6 @@
 /*
     ModbusIP.h - Header for Modbus IP Library
-    Copyright (C) 2015 André Sarmento Barbosa
+    Copyright (C) 2015 AndrÃ© Sarmento Barbosa
 */
 #include <Arduino.h>
 #include <Modbus.h>
@@ -12,6 +12,8 @@
 
 #define MODBUSIP_PORT 	  502
 #define MODBUSIP_MAXFRAME 200
+
+//#define TCP_STOP
 
 class ModbusIP : public Modbus {
     private:

--- a/libraries/ModbusIP_ENC28J60/ModbusIP_ENC28J60.cpp
+++ b/libraries/ModbusIP_ENC28J60/ModbusIP_ENC28J60.cpp
@@ -1,6 +1,6 @@
 /*
     ModbusIP_ENC28J60.cpp - Source for Modbus IP ENC28J60 Library
-    Copyright (C) 2015 André Sarmento Barbosa
+    Copyright (C) 2015 AndrÃ© Sarmento Barbosa
 */
 #include "ModbusIP_ENC28J60.h"
 
@@ -11,27 +11,27 @@ ModbusIP::ModbusIP() {
 }
 
 void ModbusIP::config(uint8_t *mac) {
-    ether.begin(sizeof Ethernet::buffer, mac, 10);
+    ether.begin(sizeof Ethernet::buffer, mac, ENC28J60_CS);
     ether.dhcpSetup();
 }
 
 void ModbusIP::config(uint8_t *mac, uint8_t * ip) {
-    ether.begin(sizeof Ethernet::buffer, mac, 10);
+    ether.begin(sizeof Ethernet::buffer, mac, ENC28J60_CS);
     ether.staticSetup(ip);
 }
 
 void ModbusIP::config(uint8_t *mac, uint8_t * ip, uint8_t * dns) {
-    ether.begin(sizeof Ethernet::buffer, mac, 10);
+    ether.begin(sizeof Ethernet::buffer, mac, ENC28J60_CS);
     ether.staticSetup(ip, 0, dns);
 }
 
 void ModbusIP::config(uint8_t *mac, uint8_t * ip, uint8_t * dns, uint8_t * gateway) {
-    ether.begin(sizeof Ethernet::buffer, mac, 10);
+    ether.begin(sizeof Ethernet::buffer, mac, ENC28J60_CS);
     ether.staticSetup(ip, gateway, dns);
 }
 
 void ModbusIP::config(uint8_t *mac, uint8_t * ip, uint8_t * dns, uint8_t * gateway, uint8_t * subnet) {
-    ether.begin(sizeof Ethernet::buffer, mac, 10);
+    ether.begin(sizeof Ethernet::buffer, mac, ENC28J60_CS);
     ether.staticSetup(ip, gateway, dns, subnet);
 }
 
@@ -68,7 +68,13 @@ void ModbusIP::task() {
             BufferFiller bfill = ether.tcpOffset();
             bfill.emit_raw((const char *)_MBAP, 7);
             bfill.emit_raw((const char *)_frame, _len);
+#ifdef TCP_STOP
             ether.httpServerReply(bfill.position());
+#else
+            ether.httpServerReplyAck ();
+            ether.httpServerReply_with_flags(bfill.position(), TCP_FLAGS_ACK_V|TCP_FLAGS_PUSH_V);
+#endif
+
         }
 
         free(_frame);

--- a/libraries/ModbusIP_ENC28J60/ModbusIP_ENC28J60.h
+++ b/libraries/ModbusIP_ENC28J60/ModbusIP_ENC28J60.h
@@ -1,6 +1,6 @@
 /*
     ModbusIP_ENC28J60.h - Header for Modbus IP ENC28J60 Library
-    Copyright (C) 2015 André Sarmento Barbosa
+    Copyright (C) 2015 AndrÃ© Sarmento Barbosa
 */
 #include <Arduino.h>
 #include <Modbus.h>
@@ -11,6 +11,9 @@
 
 #define MODBUSIP_PORT 	  502
 #define MODBUSIP_MAXFRAME 200
+
+#define ENC28J60_CS 	10 //Default chip select pin
+//#define TCP_STOP
 
 class ModbusIP : public Modbus {
     private:


### PR DESCRIPTION
I tried to use this wonderful library with the [AdvancedHMI](http://www.advancedhmi.com/) project, but unfortunately it appeared that works nothing... It appeared also that [IGSS SCADA](http://igss.schneider-electric.com/products/igss/download/free-scada.aspx) terribly freezes. [MasterOPC](http://www.masteropc.ru/prices/info.php?pid=6944) sends the duplicated requests.
In CAS Modbus Scanner it was required to "disconnect" after each "poll"... 
Mudbus library works perfectly with all last ones. It was clarified that in Mudbus there is no "client.stop ()" function call.  With enc28j60 it was slightly more difficult.
I am not sure as far as this correct decision, but everything began to work perfectly.
