### PR TITLE
Modified to allow a custom SS (Chip Select) pin

### DIFF
--- a/libraries/ModbusIP_ENC28J60/ModbusIP_ENC28J60.cpp
+++ b/libraries/ModbusIP_ENC28J60/ModbusIP_ENC28J60.cpp
@@ -6,8 +6,14 @@
 
 byte Ethernet::buffer[MODBUSIP_MAXFRAME];
 
+uint8_t ENC28J60_CS = 10;   //Default chip select pin
+
 ModbusIP::ModbusIP() {
     ether.hisport = MODBUSIP_PORT;
+}
+
+void ModbusIP::setSS(uint8_t ssPin) {
+    ENC28J60_CS = ssPin;
 }
 
 void ModbusIP::config(uint8_t *mac) {

--- a/libraries/ModbusIP_ENC28J60/ModbusIP_ENC28J60.h
+++ b/libraries/ModbusIP_ENC28J60/ModbusIP_ENC28J60.h
@@ -12,7 +12,7 @@
 #define MODBUSIP_PORT 	  502
 #define MODBUSIP_MAXFRAME 200
 
-#define ENC28J60_CS 	10 //Default chip select pin
+//#define ENC28J60_CS 	10 //Default chip select pin
 //#define TCP_KEEP_ALIVE
 
 class ModbusIP : public Modbus {
@@ -21,6 +21,7 @@ class ModbusIP : public Modbus {
 
     public:
         ModbusIP();
+        void setSS(uint8_t ssPin);
         void config(uint8_t *mac);
         void config(uint8_t *mac, uint8_t * ip);
         void config(uint8_t *mac, uint8_t * ip, uint8_t * dns);


### PR DESCRIPTION
Modified to allow a custom SS (Chip Select) pin. I'm using multiple SPI devices on my Arduino Mega and it's easier to be able to select manually a SS. Also, it defaults to pin 10, so it would be transparent to all existing installs