### PR TITLE
Fixed error that skipped every coil which is at a reference multiple of 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,6 @@ I also thought it would be cool have a base library for Modbus and derive it for
 I appreciate the work of all the authors of the other libraries, of which I used several ideas to compose the modbus-arduino.
 At the end of this document is a list of libraries and their authors.
 
-Why this fork?
-==============
-This fork fixes a few issues that I found where the coils and references which are multiples of 8 weren't working correctly. It was just a small (but significant) iterator issue.
-
 Features
 ========
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ I also thought it would be cool have a base library for Modbus and derive it for
 I appreciate the work of all the authors of the other libraries, of which I used several ideas to compose the modbus-arduino.
 At the end of this document is a list of libraries and their authors.
 
+Why this fork?
+==============
+This fork fixes a few issues that I found where the coils and references which are multiples of 8 weren't working correctly. It was just a small (but significant) iterator issue.
+
 Features
 ========
 

--- a/libraries/Modbus/Modbus.cpp
+++ b/libraries/Modbus/Modbus.cpp
@@ -216,7 +216,7 @@ void Modbus::readRegisters(word startreg, word numregs) {
 
     word val;
     word i = 0;
-	while(numregs--) {
+	while(numregs) {
         //retrieve the value from the register bank for the current register
         val = this->Hreg(startreg + i);
         //write the high byte of the register value
@@ -224,6 +224,7 @@ void Modbus::readRegisters(word startreg, word numregs) {
         //write the low byte of the register value
         _frame[3 + i * 2] = val & 0xFF;
         i++;
+		numregs--;
 	}
 
     _reply = MB_REPLY_NORMAL;
@@ -278,10 +279,11 @@ void Modbus::writeMultipleRegisters(byte* frame,word startreg, word numoutputs, 
 
     word val;
     word i = 0;
-	while(numoutputs--) {
+	while(numoutputs) {
         val = (word)frame[6+i*2] << 8 | (word)frame[7+i*2];
         this->Hreg(startreg + i, val);
         i++;
+		numoutputs--;
 	}
 
     _reply = MB_REPLY_NORMAL;

--- a/libraries/Modbus/Modbus.cpp
+++ b/libraries/Modbus/Modbus.cpp
@@ -326,8 +326,8 @@ void Modbus::readCoils(word startreg, word numregs) {
     byte bitn = 0;
     word totregs = numregs;
     word i;
-	while (numregs--) {
-        i = (totregs - numregs) / 8;
+	while (numregs) {
+        i = (totregs - numregs--) / 8;
 		if (this->Coil(startreg))
 			bitSet(_frame[2+i], bitn);
 		else
@@ -496,8 +496,8 @@ void Modbus::writeMultipleCoils(byte* frame,word startreg, word numoutputs, byte
     byte bitn = 0;
     word totoutputs = numoutputs;
     word i;
-	while (numoutputs--) {
-        i = (totoutputs - numoutputs) / 8;
+	while (numoutputs) {
+        i = (totoutputs - numoutputs--) / 8;
         this->Coil(startreg, bitRead(frame[6+i], bitn));
         //increment the bit index
         bitn++;


### PR DESCRIPTION
Without this change, the 8th coil, 16th coil and so on don't behave correctly, since they never get included in the for loop. With this simple change the library works as it normally should.